### PR TITLE
Modernize duplicate report HTML with dark/light themes, timing info, …

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,12 +114,12 @@ jobs:
         file: ./Dockerfile
         tags: |
           docker.io/${{ github.actor }}/filetool:canary
-          docker.io/${{ github.actor }}/filetool:v0.6.4
+          docker.io/${{ github.actor }}/filetool:v0.6.5
           docker.io/${{ github.actor }}/filetool:${{ github.sha }}
           docker.io/${{ github.actor }}/filetool:${{ github.run_id }}
           docker.io/${{ github.actor }}/filetool:${{ steps.get_version.outputs.build_date }}
           ghcr.io/${{ github.actor }}/filetool:canary
-          ghcr.io/${{ github.actor }}/filetool:v0.6.4
+          ghcr.io/${{ github.actor }}/filetool:v0.6.5
           ghcr.io/${{ github.actor }}/filetool:${{ github.sha }}
           ghcr.io/${{ github.actor }}/filetool:${{ github.run_id }}
           ghcr.io/${{ github.actor }}/filetool:${{ steps.get_version.outputs.build_date }}
@@ -128,7 +128,7 @@ jobs:
           org.opencontainers.image.description=A tool to manage and cleanup files on your hard drive.
           org.opencontainers.image.vendor=${{ github.actor }}
           org.opencontainers.image.authors=${{ github.actor }}
-          org.opencontainers.image.version=v0.6.4
+          org.opencontainers.image.version=v0.6.5
           org.opencontainers.image.url=${{ github.event.repository.clone_url }}
           org.opencontainers.image.source=${{ github.event.repository.clone_url }}
           org.opencontainers.image.created=${{ steps.get_version.outputs.build_timestamp }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetool"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "cargo-tarpaulin",
  "chrono",
@@ -1313,9 +1313,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6835eea34fb6321b9b3aa7b685c2b433948c09447e389dc017fdf687d5d11e65"
+checksum = "30457d51cb0e68ee18184b30cd9eb8e1602a20837c321f6ea9706b94f1c681c3"
 dependencies = [
  "jiff-static",
  "log",
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c22e04db9c58f5136eb1757f3d5c49a7b187f49e52185228cbd2f5acdfcc08c"
+checksum = "05f86e4f0326c61ae6c00b04d9009aaeda644d0b5bdfbf6c67247f492f42b3f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "filetool"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 authors = ["Jeremy Edwards <1312331+jeremyje@users.noreply.github.com>"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Options:
 
 Linux
 
-`curl -o filetool -O -L https://github.com/jeremyje/filetools/releases/download/v0.6.4/filetool; chmod +x filetool`
+`curl -o filetool -O -L https://github.com/jeremyje/filetools/releases/download/v0.6.5/filetool; chmod +x filetool`
 
 Windows
 
-`(New-Object System.Net.WebClient).DownloadFile("https://github.com/jeremyje/filetools/releases/download/v0.6.4/filetool.exe", "filetool.exe")`
+`(New-Object System.Net.WebClient).DownloadFile("https://github.com/jeremyje/filetools/releases/download/v0.6.5/filetool.exe", "filetool.exe")`

--- a/src/duplicate/embed/templates/duplicate-report.html
+++ b/src/duplicate/embed/templates/duplicate-report.html
@@ -1,121 +1,190 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
 <head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Duplicates of {{title}}</title>
 	<style>
-		@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+		:root {
+			--bg: #e8f2fb;
+			--header-bg: #1565c0;
+			--header-text: #ffffff;
+			--card-bg: #ffffff;
+			--card-border: #90caf9;
+			--card-shadow: rgba(21, 101, 192, 0.12);
+			--row-odd: #e3f2fd;
+			--row-even: #f5faff;
+			--row-hover: #bbdefb;
+			--text: #1a2332;
+			--link: #1565c0;
+			--link-hover: #0d47a1;
+			--size-text: #546e7a;
+			--meta-text: #607d8b;
+			--radius: 8px;
+		}
 
-		body {
-			font-family: 'Roboto', Arial, Helvetica, sans-serif;
-			font-size: 14px;
+		@media (prefers-color-scheme: dark) {
+			:root {
+				--bg: #0d1117;
+				--header-bg: #1c2333;
+				--header-text: #e6edf3;
+				--card-bg: #1c2333;
+				--card-border: #30363d;
+				--card-shadow: rgba(0, 0, 0, 0.4);
+				--row-odd: #1c2333;
+				--row-even: #161b22;
+				--row-hover: #2d3748;
+				--text: #e6edf3;
+				--link: #79c0ff;
+				--link-hover: #a5d6ff;
+				--size-text: #8b949e;
+				--meta-text: #8b949e;
+			}
+		}
+
+		* {
+			box-sizing: border-box;
 			margin: 0;
 			padding: 0;
 		}
 
-		.title {
-			font-weight: 100;
-			font-size: 2em;
-			font-family: Roboto, Arial, Helvetica, sans-serif;
-			width: auto;
-			left: 0;
-			right: 0;
+		body {
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
+			font-size: 14px;
+			background-color: var(--bg);
+			color: var(--text);
+			line-height: 1.5;
+		}
+
+		.header {
+			background-color: var(--header-bg);
+			color: var(--header-text);
+			padding: 0.875rem 1.25rem;
+			border-radius: 0 0 var(--radius) var(--radius);
+			position: sticky;
 			top: 0;
-			border-bottom-left-radius: .5em;
-			border-bottom-right-radius: .5em;
-			color: #EEEEEE;
-			background-color: #003366;
-			padding: .5em;
-			margin-top: 0;
+			z-index: 100;
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+		}
+
+		.header h1 {
+			font-weight: 300;
+			font-size: 1.5em;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		.header-meta {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 1rem;
+			margin-top: 0.375rem;
+			font-size: 0.8em;
+			opacity: 0.8;
+		}
+
+		.content {
+			padding: 1rem;
+		}
+
+		.group-list {
+			list-style: none;
+			display: flex;
+			flex-direction: column;
+			gap: 0.625rem;
+		}
+
+		.group-card {
+			background-color: var(--card-bg);
+			border: 1px solid var(--card-border);
+			border-radius: var(--radius);
+			box-shadow: 0 1px 4px var(--card-shadow);
+			overflow: hidden;
+			content-visibility: auto;
+			contain-intrinsic-size: 0 80px;
+		}
+
+		.file-list {
+			list-style: none;
+		}
+
+		.file-row {
+			display: flex;
+			align-items: baseline;
+			justify-content: space-between;
+			gap: 1rem;
+			padding: 0.375rem 0.75rem;
+		}
+
+		.file-row:nth-child(odd) {
+			background-color: var(--row-odd);
+		}
+
+		.file-row:nth-child(even) {
+			background-color: var(--row-even);
+		}
+
+		.file-row:hover {
+			background-color: var(--row-hover);
+		}
+
+		.file-link {
+			color: var(--link);
+			text-decoration: none;
+			font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+			font-size: 0.85em;
+			overflow-wrap: anywhere;
+			flex: 1 1 0;
+			min-width: 0;
+		}
+
+		.file-link:hover {
+			color: var(--link-hover);
+			text-decoration: underline;
+		}
+
+		.file-size {
+			color: var(--size-text);
+			font-size: 0.8em;
+			white-space: nowrap;
+			flex-shrink: 0;
+			user-select: none;
+			-webkit-user-select: none;
+		}
+
+		.footer {
 			text-align: center;
-		}
-
-		pre {
-			font-family: Consolas, monospace;
-			font-size: 12px;
-		}
-
-		ul {
-			list-style-type: none;
-		}
-
-		.big-list {
-			border-radius: .25em;
-			border: 2px solid #CCDDFF;
-			background-color: #CCDDFF;
-			list-style-type: none;
-			left: 0;
-			right: 0;
-			width: auto;
-			padding: .25em;
-			margin: .5em;
-		}
-
-		ul.inner-list {
-			left: 0;
-			right: 0;
-			width: auto;
-			padding: .1em;
-			margin: .1em;
-			background-color: transparent;
-			border: 0;
-		}
-
-		ul.inner-list>li {
-			background-color: transparent;
-		}
-
-		ul.inner-list>li:nth-child(even) {
-			background-color: transparent;
-		}
-
-		ul.inner-list>li:nth-child(even):hover {
-			background-color: transparent;
-		}
-
-		ul.inner-list>li:nth-child(odd) {
-			background-color: transparent;
-		}
-
-		ul.inner-list>li:nth-child(odd):hover {
-			background-color: transparent;
-		}
-
-		.big-list li {
-			padding: .25em;
-		}
-
-		.big-list li:nth-child(odd) {
-			background-color: #DDEEFF;
-		}
-
-		.big-list li:nth-child(odd):hover {
-			background-color: #AABBCC;
-		}
-
-		.big-list li:nth-child(even) {
-			background-color: #CCDDEE;
-		}
-
-		.big-list li:nth-child(even):hover {
-			background-color: #99AABB;
+			padding: 1.25rem 1rem;
+			color: var(--meta-text);
+			font-size: 0.8em;
 		}
 	</style>
 </head>
-
 <body>
-	<h1 class="title">Duplicates of: {{title}}</h1>
-	<ul class="big-list">
-    {{#each groups}}
-		<li>
-			<ul class="inner-list">
-        {{#each this}}
-				<li><a href="file://{{path}}">{{path}}</a> {{humansize size ~}}</li>
-        {{/each}}
-			</ul>
-		</li>
-    {{/each}}
-	</ul>
+	<div class="header">
+		<h1>Duplicates of: {{title}}</h1>
+		<div class="header-meta">
+			<span>{{num_groups}} duplicate groups</span>{{#if timestamp}}
+			<span>Generated: {{timestamp}}</span>
+			<span>Duration: {{duration}}</span>{{/if}}
+		</div>
+	</div>
+	<div class="content">
+		<ul class="group-list">
+		{{#each groups}}
+			<li class="group-card">
+				<ul class="file-list">
+				{{#each this}}
+					<li class="file-row"><a href="file://{{path}}" class="file-link">{{path}}</a><span class="file-size" aria-hidden="true">{{humansize size ~}}</span></li>
+				{{/each}}
+				</ul>
+			</li>
+		{{/each}}
+		</ul>
+	</div>
+	{{#if timestamp}}
+	<div class="footer">Report generated on {{timestamp}} · Completed in {{duration}}</div>
+	{{/if}}
 </body>
-
 </html>

--- a/src/duplicate/embed/templates/duplicate-report.html
+++ b/src/duplicate/embed/templates/duplicate-report.html
@@ -129,14 +129,17 @@
 			background-color: var(--row-hover);
 		}
 
+		.file-path {
+			flex: 1 1 0;
+			min-width: 0;
+			overflow-wrap: anywhere;
+			font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+			font-size: 0.85em;
+		}
+
 		.file-link {
 			color: var(--link);
 			text-decoration: none;
-			font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
-			font-size: 0.85em;
-			overflow-wrap: anywhere;
-			flex: 1 1 0;
-			min-width: 0;
 		}
 
 		.file-link:hover {
@@ -176,7 +179,7 @@
 			<li class="group-card">
 				<ul class="file-list">
 				{{#each this}}
-					<li class="file-row"><a href="file://{{path}}" class="file-link">{{path}}</a><span class="file-size" aria-hidden="true">{{humansize size ~}}</span></li>
+					<li class="file-row"><span class="file-path"><a href="file://{{path}}" class="file-link">{{path}}</a></span><span class="file-size" aria-hidden="true">{{humansize size ~}}</span></li>
 				{{/each}}
 				</ul>
 			</li>

--- a/src/duplicate/mod.rs
+++ b/src/duplicate/mod.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use crate::common::fs::FileMetadata;
+use chrono::Local;
 use log::{trace, warn};
 use std::io;
+use std::time::Instant;
 mod db;
 mod pipeline;
 mod report;
@@ -81,6 +83,8 @@ pub(crate) fn run(args: &Args, verbose: Verbosity) -> io::Result<()> {
     let walk_join = crate::common::fs::threaded_walk_dir(&args.path, path_tx)?;
 
     let duplicate_thread = std::thread::spawn(move || {
+        let scan_start = Instant::now();
+        let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S %z").to_string();
         let mut checksum_db = crate::common::db::FileChecksumDB::new();
         match checksum_db.load(&thread_args.db) {
             Ok(()) => {}
@@ -166,11 +170,14 @@ pub(crate) fn run(args: &Args, verbose: Verbosity) -> io::Result<()> {
             delete_size: delete_size_str,
             dry_run: thread_args.dry_run,
         };
+        let duration = humantime::format_duration(scan_start.elapsed()).to_string();
         write_report(
             &thread_args,
             &report_title,
             &dups,
             &summary,
+            &timestamp,
+            &duration,
             &pb_title,
             &pb_detail,
         );
@@ -198,6 +205,8 @@ fn write_report(
     report_title: &str,
     dups: &Vec<Vec<FileMetadata>>,
     summary: &ReportSummary,
+    timestamp: &str,
+    duration: &str,
     pb_title: &indicatif::ProgressBar,
     pb_detail: &indicatif::ProgressBar,
 ) {
@@ -238,7 +247,7 @@ fn write_report(
             )),
         }
     } else {
-        match report::html_file(&args.output, report_title, dups) {
+        match report::html_file(&args.output, report_title, dups, timestamp, duration) {
             Ok(()) => {
                 pb_title.finish_with_message(format!("Scanned {files_scanned} files and found {num_dups} duplicates ({dup_size}). {deleted_text} {num_delete} files ({delete_size}). See {output_file}", output_file = args.output));
                 pb_detail.finish_and_clear();

--- a/src/duplicate/report.rs
+++ b/src/duplicate/report.rs
@@ -41,24 +41,32 @@ pub(crate) fn html_file(
     output_path: &str,
     title: &str,
     dups: &Vec<Vec<crate::common::fs::FileMetadata>>,
+    timestamp: &str,
+    duration: &str,
 ) -> std::io::Result<()> {
-    let contents = html(title, dups).unwrap();
+    let contents = html(title, dups, timestamp, duration).unwrap();
     fs::write(output_path, contents)
 }
 
 pub(crate) fn html(
     title: &str,
     dups: &Vec<Vec<crate::common::fs::FileMetadata>>,
+    timestamp: &str,
+    duration: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
     let mut reg = Handlebars::new();
     reg.set_strict_mode(true);
     reg.register_helper("humansize", Box::new(humansize));
     reg.register_template_string("duplicate-report", DUPLICATE_REPORT_HTML)?;
+    let num_groups = dups.len();
     Ok(reg.render(
         "duplicate-report",
         &json!({
             "title": title,
             "groups": dups,
+            "timestamp": timestamp,
+            "duration": duration,
+            "num_groups": num_groups,
         }),
     )?)
 }
@@ -91,12 +99,155 @@ fn humansize(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::SystemTime;
+
+    fn make_group(paths_and_sizes: &[(&str, u64)]) -> Vec<FileMetadata> {
+        let t = SystemTime::UNIX_EPOCH;
+        paths_and_sizes
+            .iter()
+            .map(|(path, size)| FileMetadata::new(path, *size, t, t))
+            .collect()
+    }
+
     #[test]
     fn test_empty_html() {
         let dups = Vec::new();
-        assert_eq!(
-            include_str!("embed/testdata/test-report.html"),
-            html("Duplicate Title String", &dups).unwrap()
-        );
+        let output = html("Duplicate Title String", &dups, "", "").unwrap();
+        assert!(output.contains("Duplicate Title String"));
+        assert!(output.contains("<!DOCTYPE html>"));
+        assert!(output.contains("0 duplicate groups"));
+        assert!(!output.contains("{{"));
+    }
+
+    #[test]
+    fn test_html_with_timestamp_and_duration() {
+        let dups = Vec::new();
+        let output = html("My Title", &dups, "2024-01-15 14:30:45 -0700", "1m 23s").unwrap();
+        assert!(output.contains("2024-01-15 14:30:45 -0700"));
+        assert!(output.contains("1m 23s"));
+    }
+
+    #[test]
+    fn test_html_without_timestamp_omits_timing_section() {
+        let dups = Vec::new();
+        let output = html("My Title", &dups, "", "").unwrap();
+        assert!(!output.contains("Generated:"));
+        assert!(!output.contains("Duration:"));
+        assert!(!output.contains("Report generated on"));
+    }
+
+    #[test]
+    fn test_html_group_count_single_group() {
+        let dups = vec![make_group(&[("/a/file.txt", 1000), ("/b/file.txt", 1000)])];
+        let output = html("Title", &dups, "", "").unwrap();
+        assert!(output.contains("1 duplicate groups"));
+    }
+
+    #[test]
+    fn test_html_group_count_multiple_groups() {
+        let dups = vec![
+            make_group(&[("/a/file1.txt", 500), ("/b/file1.txt", 500)]),
+            make_group(&[("/c/photo.jpg", 2048), ("/d/photo.jpg", 2048)]),
+            make_group(&[("/e/doc.pdf", 4096), ("/f/doc.pdf", 4096)]),
+        ];
+        let output = html("Title", &dups, "", "").unwrap();
+        assert!(output.contains("3 duplicate groups"));
+    }
+
+    #[test]
+    fn test_html_renders_file_paths() {
+        let dups = vec![make_group(&[
+            ("/home/user/photos/vacation.jpg", 1_500_000),
+            ("/backup/photos/vacation.jpg", 1_500_000),
+        ])];
+        let output = html("Title", &dups, "", "").unwrap();
+        assert!(output.contains("/home/user/photos/vacation.jpg"));
+        assert!(output.contains("/backup/photos/vacation.jpg"));
+    }
+
+    #[test]
+    fn test_html_renders_human_readable_file_sizes() {
+        let dups = vec![make_group(&[
+            ("/a/large.bin", 10 * 1024 * 1024),
+            ("/b/large.bin", 10 * 1024 * 1024),
+        ])];
+        let output = html("Title", &dups, "", "").unwrap();
+        assert!(output.contains("10") && (output.contains("MiB") || output.contains("MB")));
+    }
+
+    #[test]
+    fn test_html_file_links_use_file_scheme() {
+        let dups = vec![make_group(&[
+            ("/some/path/file.txt", 100),
+            ("/other/path/file.txt", 100),
+        ])];
+        let output = html("Title", &dups, "", "").unwrap();
+        assert!(output.contains("href=\"file:///some/path/file.txt\""));
+        assert!(output.contains("href=\"file:///other/path/file.txt\""));
+    }
+
+    #[test]
+    fn test_html_has_dark_mode_media_query() {
+        let output = html("Title", &Vec::new(), "", "").unwrap();
+        assert!(output.contains("prefers-color-scheme: dark"));
+    }
+
+    #[test]
+    fn test_html_file_size_has_user_select_none() {
+        let output = html("Title", &Vec::new(), "", "").unwrap();
+        assert!(output.contains("user-select: none"));
+    }
+
+    #[test]
+    fn test_html_has_content_visibility_for_large_list_performance() {
+        let output = html("Title", &Vec::new(), "", "").unwrap();
+        assert!(output.contains("content-visibility: auto"));
+    }
+
+    #[test]
+    fn test_html_header_is_sticky() {
+        let output = html("Title", &Vec::new(), "", "").unwrap();
+        assert!(output.contains("position: sticky"));
+    }
+
+    #[test]
+    fn test_html_file_writes_output_with_timing() {
+        let dups = vec![make_group(&[
+            ("/a/duplicate.txt", 256),
+            ("/b/duplicate.txt", 256),
+        ])];
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("report.html");
+        html_file(
+            path.to_str().unwrap(),
+            "Test Title",
+            &dups,
+            "2024-06-01 12:00:00 +0000",
+            "5s",
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("Test Title"));
+        assert!(content.contains("/a/duplicate.txt"));
+        assert!(content.contains("2024-06-01 12:00:00 +0000"));
+        assert!(content.contains("5s"));
+    }
+
+    #[test]
+    fn test_html_title_appears_in_page_title_and_heading() {
+        let output = html("My Scan Path", &Vec::new(), "", "").unwrap();
+        assert!(output.contains("<title>Duplicates of My Scan Path</title>"));
+        assert!(output.contains("Duplicates of: My Scan Path"));
+    }
+
+    #[test]
+    fn test_html_no_unrendered_template_variables() {
+        let dups = vec![
+            make_group(&[("/a/f1.txt", 100), ("/b/f1.txt", 100)]),
+            make_group(&[("/c/f2.png", 500), ("/d/f2.png", 500)]),
+        ];
+        let output = html("Title", &dups, "2024-01-01 00:00:00 +0000", "30s").unwrap();
+        assert!(!output.contains("{{"));
+        assert!(!output.contains("}}"));
     }
 }


### PR DESCRIPTION
…and better UX

- Redesign template with blue ocean (light) and twilight (dark) themes via CSS custom properties and prefers-color-scheme media query
- Add sticky header with group count, generation timestamp, and scan duration
- Put file size in user-select:none span so copy-pasting a row yields just the path
- Add content-visibility:auto on group cards for large-list rendering performance
- Round corners on cards and header using CSS variables
- Thread timestamp (chrono) and duration (humantime) from run() through to html()
- Expand report tests from 1 snapshot assertion to 15 property-based assertions