### PR TITLE
Add checksum checkpointing, auto-glob literals, and CLI doc comments.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1313,9 +1313,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30457d51cb0e68ee18184b30cd9eb8e1602a20837c321f6ea9706b94f1c681c3"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "log",
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f86e4f0326c61ae6c00b04d9009aaeda644d0b5bdfbf6c67247f492f42b3f3"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1480,9 +1480,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"

--- a/src/checksum/mod.rs
+++ b/src/checksum/mod.rs
@@ -14,6 +14,7 @@
 use clap_verbosity_flag::Verbosity;
 use log::warn;
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 #[derive(clap::Args)]
 pub(crate) struct Args {
@@ -26,6 +27,9 @@ pub(crate) struct Args {
     /// Number of threads for calculating checksums.
     #[arg(long, default_value_t = 2)]
     pub(crate) checksum_threads: usize,
+    /// How often to save the checksum database to disk during scanning. Shorter intervals reduce data loss if the process is interrupted.
+    #[arg(long, default_value = "30s", value_parser = humantime::parse_duration)]
+    pub(crate) checksum_checkpoint_interval: Duration,
 }
 
 pub(crate) fn run(args: &Args, verbose: Verbosity) -> std::io::Result<()> {
@@ -44,6 +48,7 @@ pub(crate) fn run(args: &Args, verbose: Verbosity) -> std::io::Result<()> {
         crate::common::checksum::worker_pool(args.checksum_threads, hash_result_tx, &hash_rx);
 
     let checksum_db_filepath = std::path::PathBuf::from(&args.output);
+    let checkpoint_interval = args.checksum_checkpoint_interval;
 
     let checksummer_thread = std::thread::spawn(move || {
         pb_title.set_prefix("Checksum");
@@ -75,6 +80,7 @@ pub(crate) fn run(args: &Args, verbose: Verbosity) -> std::io::Result<()> {
         drop(hash_tx);
 
         pb_detail.set_prefix("Checksum");
+        let mut last_checkpoint_time = Instant::now();
         for hash_result in hash_result_rx {
             let p: &std::path::Path = &hash_result.path;
 
@@ -83,6 +89,17 @@ pub(crate) fn run(args: &Args, verbose: Verbosity) -> std::io::Result<()> {
                     pb_detail.set_message(format!("{}", md.path.display()));
                     pb_checksum_bar.inc(1);
                     checksum_db.put(md, &hash_result.checksum);
+                    let now = Instant::now();
+                    if now.duration_since(last_checkpoint_time) >= checkpoint_interval {
+                        last_checkpoint_time = now;
+                        match checksum_db.write(&checksum_db_filepath) {
+                            Ok(()) => {}
+                            Err(error) => warn!(
+                                "cannot save checksums to '{}', error: {error}",
+                                checksum_db_filepath.display()
+                            ),
+                        }
+                    }
                 }
             }
         }
@@ -110,6 +127,7 @@ mod tests {
             path: vec![std::path::PathBuf::from(".")],
             output: std::path::PathBuf::from("checksums.txt"),
             checksum_threads: 2,
+            checksum_checkpoint_interval: humantime::parse_duration("10s").unwrap(),
         };
         run(&args, Verbosity::new(0, 0)).unwrap();
     }

--- a/src/duplicate/pipeline.rs
+++ b/src/duplicate/pipeline.rs
@@ -110,7 +110,14 @@ pub(crate) fn compile_patterns(patterns: &[String]) -> Vec<glob::Pattern> {
     patterns
         .iter()
         .filter(|p| !p.is_empty())
-        .filter_map(|p| glob::Pattern::new(p).ok())
+        .map(|p| {
+            if p.chars().any(|c| matches!(c, '*' | '?' | '[' | ']')) {
+                p.to_string()
+            } else {
+                format!("*{p}*")
+            }
+        })
+        .filter_map(|p| glob::Pattern::new(&p).ok())
         .collect()
 }
 
@@ -430,6 +437,30 @@ mod tests {
 
     fn p(s: &str) -> glob::Pattern {
         glob::Pattern::new(s).unwrap()
+    }
+
+    #[test]
+    fn test_compile_patterns_wraps_literals() {
+        let patterns = compile_patterns(&[String::from("Downloads")]);
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].matches("/home/user/Downloads/file.txt"));
+        assert!(patterns[0].matches("E:\\Downloads\\file.txt"));
+        assert!(!patterns[0].matches("/home/user/Other/file.txt"));
+    }
+
+    #[test]
+    fn test_compile_patterns_preserves_wildcards() {
+        let patterns = compile_patterns(&[String::from("**/Downloads/**")]);
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].as_str(), "**/Downloads/**");
+    }
+
+    #[test]
+    fn test_compile_patterns_wraps_literal_with_spaces() {
+        let patterns = compile_patterns(&[String::from("spaces ")]);
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].matches("/home/spaces stuff/file.txt"));
+        assert!(!patterns[0].matches("/home/user/file.txt"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,10 @@ extern crate concat_string;
 #[command(author, version, about, long_about = None)]
 #[command(next_line_help = true)]
 struct Cli {
+    /// The subcommand to run.
     #[command(subcommand)]
     command: Commands,
+    /// Controls log output level. Use -v for info, -vv for debug, -vvv for trace. Use -q to suppress warnings, -qq for silence.
     #[command(flatten)]
     verbose: Verbosity,
 }


### PR DESCRIPTION
- Wire up checksum_checkpoint_interval in checksum subcommand to periodically save the DB during scanning
- Auto-wrap literal delete/keep patterns with * wildcards so bare strings like "Downloads" match anywhere in a path
- Add doc comments for command and verbose fields in Cli struct